### PR TITLE
Add Restart item to File Menu

### DIFF
--- a/menus/restart-atom.json
+++ b/menus/restart-atom.json
@@ -21,6 +21,15 @@
           ]
         }
       ]
+    },
+    {
+      "label": "File",
+      "submenu": [
+        {
+          "label": "Restart",
+          "command": "restart-atom:restart"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
I look for the Restart option in the File menu, since that's where the Quit and Close all Tabs options reside, so this just puts it there in addition to the other menus.